### PR TITLE
ci: add build image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build Image
+
+on: [push]
+
+jobs:
+  build:
+    name: Build default
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: | 
+          sudo apt update && sudo apt install -y \
+          libarchive-tools \
+          arch-install-scripts \
+          binfmt-support \
+          qemu-user-static
+
+      - name: Build default
+        run: sudo ./aarch64-arch-mkimg default
+
+      - name: Archive build artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: default.img
+          path: build/disk.img

--- a/lib/base/source.sh
+++ b/lib/base/source.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -x
 
 _ROOTFS_ARCHIVE="ArchLinuxARM-aarch64-latest.tar.gz"
 _ROOTFS_URL="http://os.archlinuxarm.org/os/${_ROOTFS_ARCHIVE}"
@@ -9,7 +10,7 @@ _prepare_source_directories() {
 }
 
 _get_gpg_keys() {
-    gpg --recv-keys "${_ALARM_GPG_KEY}" > /dev/null  2>&1
+    gpg --keyserver keyserver.ubuntu.com --recv-keys "${_ALARM_GPG_KEY}" > /dev/null  2>&1
 }
 
 _download() {


### PR DESCRIPTION
This PR adds the ability to build the image using the CI.

Unfortuantely the CI fails, but I think there is an issue with the linux-surface Arch package repository:

```
debug: linux-firmware-msft-surface-pro-x-20220509.b19cbdc-1-any.pkg.tar.zst.sig: maxsize 16384
debug: linux-firmware-msft-surface-pro-x-20220509.b19cbdc-1-any.pkg.tar.zst.sig: opened tempfile for download: /var/cache/pacman/pkg/linux-firmware-msft-surface-pro-x-20220509.b19cbdc-1-any.pkg.tar.zst.sig.part (wb)
debug: linux-firmware-msft-surface-pro-x-20220509.b19cbdc-1-any.pkg.tar.zst.sig: curl returned result 0 from transfer
debug: linux-firmware-msft-surface-pro-x-20220509.b19cbdc-1-any.pkg.tar.zst.sig: response code 200
debug: linux-firmware-msft-surface-pro-x-qcom-20220509.b19cbdc-1-any.pkg.tar.zst: url is https://pkg.surfacelinux.com/arch-aarch64/linux-firmware-msft-surface-pro-x-qcom-20220509.b19cbdc-1-any.pkg.tar.zst
debug: linux-firmware-msft-surface-pro-x-qcom-20220509.b19cbdc-1-any.pkg.tar.zst: maxsize 85096454
debug: linux-firmware-msft-surface-pro-x-qcom-20220509.b19cbdc-1-any.pkg.tar.zst: opened tempfile for download: /var/cache/pacman/pkg/linux-firmware-msft-surface-pro-x-qcom-20220509.b19cbdc-1-any.pkg.tar.zst.part (wb)
debug: linux-firmware-msft-surface-pro-x-qcom-20220509.b19cbdc-1-any.pkg.tar.zst: curl returned result 0 from transfer
debug: linux-firmware-msft-surface-pro-x-qcom-20220509.b19cbdc-1-any.pkg.tar.zst: response code 200
debug: linux-firmware-msft-surface-pro-x-qcom-20220509.b19cbdc-1-any.pkg.tar.zst.sig: url is https://pkg.surfacelinux.com/arch-aarch64/linux-firmware-msft-surface-pro-x-qcom-20220509.b19cbdc-1-any.pkg.tar.zst.sig
debug: linux-firmware-msft-surface-pro-x-qcom-20220509.b19cbdc-1-any.pkg.tar.zst.sig: maxsize 16384
debug: linux-firmware-msft-surface-pro-x-qcom-20220509.b19cbdc-1-any.pkg.tar.zst.sig: opened tempfile for download: /var/cache/pacman/pkg/linux-firmware-msft-surface-pro-x-qcom-20220509.b19cbdc-1-any.pkg.tar.zst.sig.part (wb)
debug: linux-firmware-msft-surface-pro-x-qcom-20220509.b19cbdc-1-any.pkg.tar.zst.sig: curl returned result 18 from transfer
error: failed retrieving file 'linux-firmware-msft-surface-pro-x-qcom-20220509.b19cbdc-1-any.pkg.tar.zst.sig' from pkg.surfacelinux.com : 
debug: linux-firmware-msft-surface-pro-x-qcom-20220509.b19cbdc-1-any.pkg.tar.zst.sig: no more servers to retry
debug: curl_download_internal return code is -1
warning: failed to retrieve some files
error: failed to commit transaction (download library error)
 linux-firmware-msft-surface-pro-x-qcom-20220509.b19cbdc-1-any downloading...
```

(see https://github.com/denysvitali/surface-pro-x-arch-linux-aarch64-images/actions/runs/4548499674/jobs/8019594944)