### PR TITLE
Feat/mirror update

### DIFF
--- a/lib/chroot/_setup.sh
+++ b/lib/chroot/_setup.sh
@@ -12,6 +12,10 @@ source "${_CHROOT_LIB}/makepkg.sh"
 source "${_CHROOT_LIB}/modules.sh"
 source "${_CHROOT_LIB}/pacman.sh"
 
+#Copy over the modified mirrorlist to /etc/pacman.d
+cp -f ${_CHROOT_LIB}/mirrorlist /etc/pacman.d/mirrorlist
+
+#Continue as normal
 _pacman_setup
 _pacman_uninstall
 _pacman_update

--- a/lib/chroot/mirrorlist
+++ b/lib/chroot/mirrorlist
@@ -1,0 +1,64 @@
+#
+# Arch Linux ARM repository mirrorlist
+# Generated on 2023-02-06
+#
+
+### => Fast mirror
+Server = https://mirror.fangshdow.trade/$arch/$repo
+
+### Alt-mirror from Berkeley OCF group
+Server = https://mirrors.ocf.berkeley.edu/archlinuxarm/$arch/$repo
+
+## Geo-IP based mirror selection and load balancing
+# Use this as a fallback
+Server = http://mirror.archlinuxarm.org/$arch/$repo
+
+### Mirrors by country
+
+### Denmark
+## Aalborg
+# Server = http://dk.mirror.archlinuxarm.org/$arch/$repo
+
+### Germany
+## Aachen
+# Server = http://de3.mirror.archlinuxarm.org/$arch/$repo
+## Berlin
+# Server = http://de.mirror.archlinuxarm.org/$arch/$repo
+## Coburg
+# Server = http://de4.mirror.archlinuxarm.org/$arch/$repo
+## Falkenstein
+# Server = http://eu.mirror.archlinuxarm.org/$arch/$repo
+# Server = http://de5.mirror.archlinuxarm.org/$arch/$repo
+
+### Greece
+## Athens
+# Server = http://gr.mirror.archlinuxarm.org/$arch/$repo
+
+### Hungary
+## Budapest
+# Server = http://hu.mirror.archlinuxarm.org/$arch/$repo
+
+### Japan
+## Tokyo
+# Server = http://jp.mirror.archlinuxarm.org/$arch/$repo
+
+### Singapore
+# Server = http://sg.mirror.archlinuxarm.org/$arch/$repo
+
+### Taiwan
+## Hsinchu
+# Server = http://tw2.mirror.archlinuxarm.org/$arch/$repo
+## New Taipei City
+# Server = http://tw.mirror.archlinuxarm.org/$arch/$repo
+
+### United Kingdom
+## London
+# Server = http://uk.mirror.archlinuxarm.org/$arch/$repo
+
+### United States
+## California
+# Server = http://ca.us.mirror.archlinuxarm.org/$arch/$repo
+## Florida
+# Server = http://fl.us.mirror.archlinuxarm.org/$arch/$repo
+## New Jersey
+# Server = http://nj.us.mirror.archlinuxarm.org/$arch/$repo


### PR DESCRIPTION
Updates were made to have a mirrorlist copied over to the chroot portion of the build and have it pull from 2 different stable repo mirrors instead of the unstable mirrors.archlinuxarm.org

##This is still a possible work in progress. I have a mirror running and it was able to pull everything with no issue. Docker container build time took the most to actually get going. (Kept running out of resources due to wslvm)