### PR TITLE
Default - Add Packages To Install

### DIFF
--- a/profiles/default/packages/install
+++ b/profiles/default/packages/install
@@ -7,3 +7,6 @@ crda
 usbutils
 htop
 neovim
+dosfstools
+arch-install-scripts
+util-linux


### PR DESCRIPTION
- `dosfstools`
    - required for installing on UEFI (format EFI partition as FAT32)
- `arch-install-scripts`
    - required for installing arch (provides `genfstab`, `arch-chroot`)   
- `util-linux`
    - required for installing arch (provides `fstab`, `fdisk`)