### PR TITLE
Switch to an ARM runner

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,5 +47,6 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -13,8 +13,12 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+
     name: Build default Image
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
       packages: write
@@ -24,6 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up QEMU
+        if: ${{ !endsWith(matrix.os, '-arm') }}
         uses: docker/setup-qemu-action@v3
 
       - name: Setup Docker buildx

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -13,12 +13,8 @@ env:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm]
-
     name: Build default Image
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
@@ -26,10 +22,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        if: ${{ !endsWith(matrix.os, '-arm') }}
-        uses: docker/setup-qemu-action@v3
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM archlinux/archlinux
+FROM pkgforge/archlinux
 
 RUN pacman --noconfirm -Syu \
     && pacman --noconfirm -S wget libarchive arch-install-scripts \

--- a/lib/base/img.sh
+++ b/lib/base/img.sh
@@ -58,22 +58,21 @@ _img_build() {
     _msg2 "Laying out partitions..."
 
     # compute EFS partition size in MiB
-    efs_size=$(du -bc "${_DIR_DISK_EFI}" | grep total | cut -f1)
-    efs_part_size=$(( (efs_size*105)/100/(1024*1024) + 1))
+    efs_part_size=$(du -s --block-size=1M "${_DIR_DISK_EFI}" | cut -f1)
 
     if [[ $efs_part_size -lt 48 ]]; then
         efs_part_size=48
     fi
 
     # compute root partition size in MiB
-    root_size=$(du -bc "${_DIR_DISK_ROOT}" | grep total | cut -f1)
-    root_part_size=$(( (root_size*110)/100/(1024*1024) + 1))
+    root_size=$(du -s --block-size=1M "${_DIR_DISK_ROOT}" | cut -f1)
+    root_part_size=$(( root_size + 128 ))
 
     # compute disk size and create base image
     _msg2 "Allocating disk image..."
     _IMG_DISK="${_DIR_BUILD}/disk.img"
 
-    disk_size=$(( efs_part_size + root_part_size + 5 ))
+    disk_size=$(( efs_part_size + root_part_size + 8 ))
     dd if=/dev/zero of="${_IMG_DISK}" bs="${disk_size}" count=1048576 status=none
     sync
 

--- a/lib/chroot/pacman.sh
+++ b/lib/chroot/pacman.sh
@@ -8,7 +8,7 @@ _pacman_setup() {
 
 _pacman_update() {
     _msg1 "Updating the system..."
-    pacman --noconfirm -Syu
+    pacman --noconfirm --disable-sandbox -Syu
 }
 
 _pacman_install() {
@@ -18,7 +18,7 @@ _pacman_install() {
         mapfile -t pkglist < "${_CHROOT_PACKAGES}/install"
 
         if [[ ${#pkglist[@]} -gt 0 ]]; then
-            pacman --noconfirm -S "${pkglist[@]}"
+            pacman --noconfirm --disable-sandbox -S "${pkglist[@]}"
         fi
     fi
 
@@ -29,7 +29,7 @@ _pacman_install() {
         shopt -u nullglob
 
         if [[ ${#pkglist[@]} -gt 0 ]]; then
-            pacman --noconfirm -U "${pkglist[@]}"
+            pacman --noconfirm --disable-sandbox -U "${pkglist[@]}"
         fi
     fi
 }
@@ -41,11 +41,11 @@ _pacman_uninstall() {
         mapfile -t pkglist < "${_CHROOT_PACKAGES}/uninstall"
 
         if [[ ${#pkglist[@]} -gt 0 ]]; then
-            pacman --noconfirm -Rns "${pkglist[@]}"
+            pacman --noconfirm --disable-sandbox -Rns "${pkglist[@]}"
         fi
     fi
 }
 
 _pacman_install_local() {
-    pacman --noconfirm -U "${@}"
+    pacman --noconfirm --disable-sandbox -U "${@}"
 }

--- a/lib/modules/linux-surface.sh
+++ b/lib/modules/linux-surface.sh
@@ -2,7 +2,7 @@
 
 __pacman_install_retry() {
     for i in {1..5}; do
-        if pacman --noconfirm -S "${@}"; then
+        if pacman --noconfirm --disable-sandbox -S "${@}"; then
             break
         fi
 
@@ -30,7 +30,7 @@ Server = https://pkg.surfacelinux.com/arch-aarch64/
 EOF
 
     # update
-    pacman --noconfirm -Syu
+    pacman --noconfirm --disable-sandbox -Syu
 
     # WORKAROUND: This is a workaround for an issue with GitHub CI. Normally,
     # we would install these packages together with the other packages via the


### PR DESCRIPTION
Hello, I have modified the Docker and the runner to use a native GitHub ARM runner.

This reduces the action time from 29 minutes to 9 minutes.

This also makes it possible to run mkimg on a Mac (it takes around 5 minutes on an M3 chip).

However, I encountered several problems: 
- I had to comment out 'systemctl enable qrtr-ns.service' because it was dropped two months ago: https://github.com/linux-msm/qrtr/commit/3edda0ebecf5d1be293a4f5f502567dda8229173.
- The newer version of Pacman requires '--disable-sandbox'.
- I had to use a community Docker image for Arch Linux because there is no official Arm version.

You can retrieve the new image: 

`docker pull ghcr.io/aquabx/aarch64-arch-mkimg:patch-1`