### PR TITLE
lib/modules/qcom-wifi: Fix broken rmtfs-dummy patches

### DIFF
--- a/lib/modules/qcom-wifi.sh
+++ b/lib/modules/qcom-wifi.sh
@@ -1,11 +1,22 @@
 #!/usr/bin/env bash
 
+_qcom_wifi_fix_rmtfs_dummy_patch() {
+    local pkgbuild="${_BUILDDIR}/ls/rmtfs-dummy/PKGBUILD"
+
+    sed -i \
+        -e 's#git apply "\$srcdir/0001-Redirect-file-lookups-to-var-lib-rmtfs.patch"#patch -p1 --fuzz=3 < "$srcdir/0001-Redirect-file-lookups-to-var-lib-rmtfs.patch"#' \
+        -e '/git apply "\$srcdir\/0001-rmtfs-Fix-command-line-argument-parsing-for-o-optarg.patch"/d' \
+        "${pkgbuild}"
+}
+
 _qcom_wifi_makepkg() {
     _msg2 "Building Qualcomm WiFi packages..."
 
     cd "${_BUILDDIR}" || exit 1
 
     _makepkg_git_clone "https://github.com/linux-surface/aarch64-packages" "ls"
+
+    _qcom_wifi_fix_rmtfs_dummy_patch
 
     _makepkg_build_install "${_BUILDDIR}/ls/qmic"
     _makepkg_build_install "${_BUILDDIR}/ls/qrtr"


### PR DESCRIPTION
## Issue

 Building the `default` profile currently fails when building the Qualcomm WiFi packages:
```bash
==> Starting prepare()...
error: patch failed: rmtfs.service.in:3
error: rmtfs.service.in: patch does not apply
==> ERROR: A failure occurred in prepare().
Aborting...
+ exit_code=4
+ sleep 1.0
+ umount -R //build/rootfs
+ return 4
```

This occurs because the two patches in `linux-surface/aarch64-packages`'s `rmtfs-dummy` package are no longer in sync with the upstream `linux-msm/rmtfs`.

1.  `0001-Redirect-file-lookups-to-var-lib-rmtfs.patch` no longer matches the upstream `rmtfs.service.in` so git apply cannot succeed. 

2. `0001-rmtfs-Fix-command-line-argument-parsing-for-o-optarg.patch` is now a no-op as the upstream has merged an equivalent fix.

### Solution

As we don't control the upstream package, this fix patches the cloned PKGBUILD in-place (`sed` before invoking `makepkg`) to:

- Apply `0001-Redirect-file-lookups-to-var-lib-rmtfs.patch`  with  `patch -p1 --fuzz=3` so the patch still applies with the new line offsets
- Drop `0001-rmtfs-Fix-command-line-argument-parsing-for-o-optarg.patch` for the aforementioned reason (no-op)

### Testing

- [x] verified both patch behaviors directly against fresh clones of  `linux-msm/rmtfs` (outside of Docker)
- [x] Ran a full local build after the fix and verified that  `rmtfs-dummy` now builds and installs correctly
- [x]  `build/disk.img` is produced successfully